### PR TITLE
Fix failing test after cloning repo for the first time.

### DIFF
--- a/test.js
+++ b/test.js
@@ -34,11 +34,12 @@ test('opts.prefix', function (t) {
 
 test('opts.dest', function (t) {
   t.plan(2)
-  runFixture('basic', t, null, {dest: 'fixtures/assets/generated'})
-  t.ok(fs.existsSync('./fixtures/assets/generated/390025aef74c5829.jpg'), 'file exists')
+  runFixture('basic', t, null, {dest: 'fixtures/assets/generated'}, function() {
+    t.ok(fs.existsSync('./fixtures/assets/generated/390025aef74c5829.jpg'), 'file exists')
+  })
 })
 
-function runFixture (dir, t, output, opts) {
+function runFixture (dir, t, output, opts, cb) {
   output = output || 'output'
   var jsFix = './fixtures/' + dir + '/index.js'
     , htmlFix = read('./fixtures/' + dir + '/' + output + '.html')
@@ -54,6 +55,7 @@ function runFixture (dir, t, output, opts) {
   b.bundle(function (err, src) {
     if (err) t.fail(err)
     vm.runInNewContext(src, { console: { log: log } })
+    if (cb) cb()
   })
 
   function log (msg) {


### PR DESCRIPTION
Currently the tests will fail on a fresh checkout of the repo, but will fail the second time the tests are run. This is because the last test is not waiting until the I/O has finished in runFixture to make its final assertion.

This fixes that issue by adding an optional callback to runFixture.

How to reproduce:
- Check out a fresh copy of the repo followed by:

```
npm install
npm test
```
- Tests should fail. Repeat `npm test` and the tests will pass.
- `rm fixtures/assets/generated/390025aef74c5829.jpg` and the test will fail again.
