### PR TITLE
Only match a src attribute

### DIFF
--- a/custom.js
+++ b/custom.js
@@ -7,7 +7,7 @@ var through = require('through')
   , url = require('url')
 
 var types = ['html']
-  , tag = /\<[img|video|audio][\S\s?!\<]*?src\=[\"\'](.*?)[\"\'][\S\s]*?\>/g
+  , tag = /\<[img|video|audio][\S\s?!\<]*?[\ \'\"]src\=[\"\'](.*?)[\"\'][\S\s]*?\>/g
   , processed
   , res
 

--- a/fixtures/other-attr/index.js
+++ b/fixtures/other-attr/index.js
@@ -1,0 +1,2 @@
+var html = require('./input.html');
+console.log(html);

--- a/fixtures/other-attr/input.html
+++ b/fixtures/other-attr/input.html
@@ -1,0 +1,4 @@
+<div>
+  <img src="../assets/images/atomify.jpg">
+  <img ng-src="../assets/images/atomify.jpg">
+</div>

--- a/fixtures/other-attr/output.html
+++ b/fixtures/other-attr/output.html
@@ -1,0 +1,4 @@
+<div>
+  <img src="atomify-390025aef74c5829.jpg">
+  <img ng-src="../assets/images/atomify.jpg">
+</div>

--- a/test.js
+++ b/test.js
@@ -46,6 +46,11 @@ test('opts.retainName', function (t) {
   })
 })
 
+test('use other attributes which ends in src', function (t) {
+  t.plan(1)
+  runFixture('other-attr', t)
+})
+
 function runFixture (dir, t, output, opts, cb) {
   output = output || 'output'
   var jsFix = './fixtures/' + dir + '/index.js'


### PR DESCRIPTION
resrcify is supposed to match src attributes, but currently, it matches
any attribute that ends in src, for instance ng-src. This makes it hard
to use other image sources. By adding a check to see if the src attribute
is following a space, a single or a doble quote, it still matches any src
tag, but not more than that.
